### PR TITLE
Update link to Hugo's current GitHub profile

### DIFF
--- a/content/coc/contents.lr
+++ b/content/coc/contents.lr
@@ -8,7 +8,7 @@ body:
 
 ### The Project Maintainers
 
-- [Hugo Osvaldo Barrera](https://github.com/hobarrera)
+- [Hugo Osvaldo Barrera](https://github.com/WhyNotHugo)
 - [Christian Geier](https://github.com/geier)
 - [Markus Unterwaditzer](https://github.com/untitaker)
 

--- a/content/contact/contents.lr
+++ b/content/contact/contents.lr
@@ -15,7 +15,7 @@ For conversations of private and *urgent* nature (such as security issues or
 violations of the [CoC](/coc/)) please write to `contact@pimutils.org`.
 Messages sent to this address will be forwarded to [Christian
 Geier](https://github.com/geier), [Hugo Osvaldo
-Barrera](https://github.com/hobarrera) and [Markus
+Barrera](https://github.com/WhyNotHugo) and [Markus
 Unterwaditzer](https://github.com/untitaker/).
 
 ### IRC


### PR DESCRIPTION
I've renamed by GitHub account, and this PR updates references to it.

Some background, just for clarity's sake:

I've been trying to simplify my online accounts by having a same username everywhere (and `hobarrera` was taken on too many places, my name+surname is _way_ too common).

I'll admit that I took the opportunity to also adopt something that's pronounceable (or at least gives some hint to others on how to refer to me on spoken scenarios), which has also been an issue many times.