### PR TITLE
Use GH Actions to keep files in sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,7 @@
+group:
+  repos:
+  - pimutils/khal
+  - pimutils/todoman
+  - pimutils/vdirsyncer
+  files:
+  - CODE_OF_CONDUCT.md

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,0 +1,21 @@
+name: Sync files to repos
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+      - uses: actions/checkout@v2
+      - uses: BetaHuhn/repo-file-sync-action@v1
+        with:
+          GH_INSTALLATION_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GIT_EMAIL: whynotbot
+          GIT_USERNAME: whynotbot


### PR DESCRIPTION
I'd like to eventually use this to sync scaffold files across all Python
repos in the org.